### PR TITLE
Center header and fix weird endblock issue

### DIFF
--- a/app/assets/sass/sunderland.scss
+++ b/app/assets/sass/sunderland.scss
@@ -50,7 +50,11 @@ $toolkit-font-stack: $helvetica-regular;
 // make Sunderland header hrefs white
 #scch1, #scch2, #scch3, #scch4, #scch5, #scch6{
 	color: white;
-} 
+}
+#sccHeaderTable{
+  max-width: 960px;
+  margin: 0 auto;
+}
 #sccHeaderTable table td{
 	border-bottom-style: none;
 }

--- a/lib/sunderland_template.html
+++ b/lib/sunderland_template.html
@@ -1,4 +1,4 @@
-﻿{% block top_of_page %}{% endblock %}
+{% block top_of_page %}{% endblock %}
 <!DOCTYPE html>
 <!--[if lt IE 9]><html class="lte-ie8 unbranded" lang="{{ html_lang|default('en') }}"><![endif]-->
 <!--[if gt IE 8]><!--><html class="sunderland" lang="{{ html_lang|default('en') }}"><!--<![endif]-->


### PR DESCRIPTION
This PR does 2 things:

 - Fixes an issue with the template HTML which made the HTML not compile properly. Probably something to do with whitespace, not 100% sure. (The [diff](https://github.com/kenmaddison-scc/verify-local-patterns/pull/2/files#diff-f96c758b05b7c7b7cc5d3920f15ea8c7) looks the same to me, I just reverted that line and it worked 🙃)
 - Centers the header with max-width for larger screens:

## Before

![screen shot 2017-03-23 at 10 45 43](https://cloud.githubusercontent.com/assets/4106955/24244230/e8d248bc-0fb5-11e7-944c-2ed78a2d4091.png)

## After

<img width="960" alt="screen shot 2017-03-23 at 10 45 51" src="https://cloud.githubusercontent.com/assets/4106955/24244235/ee258306-0fb5-11e7-9d8c-cad9450878c8.png">
